### PR TITLE
ci: Add GitHub Actions workflow for automated build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,94 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows
+          #- os: macos-latest
+          #  name: macos
+          #- os: ubuntu-latest
+          #  name: linux
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev \
+            libfreetype6-dev \
+            libgl1-mesa-dev \
+            libgtk-3-dev \
+            libx11-dev \
+            libxcomposite-dev \
+            libxcursor-dev \
+            libxext-dev \
+            libxinerama-dev \
+            libxrandr-dev \
+            libxrender-dev
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release --parallel 4
+
+      - name: Package artifacts (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "build\AltDenoiserPlugin_artefacts\Release\*" -DestinationPath "Alt-Denoiser-${{ matrix.name }}.zip"
+
+      - name: Package artifacts (macOS / Linux)
+        if: runner.os != 'Windows'
+        run: |
+          cd build/AltDenoiserPlugin_artefacts/Release
+          zip -r ${{ github.workspace }}/Alt-Denoiser-${{ matrix.name }}.zip .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Alt-Denoiser-${{ matrix.name }}
+          path: Alt-Denoiser-${{ matrix.name }}.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            Alt-Denoiser-windows/Alt-Denoiser-windows.zip
+            Alt-Denoiser-macos/Alt-Denoiser-macos.zip
+            Alt-Denoiser-linux/Alt-Denoiser-linux.zip


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and releasing the project. The workflow automates building the project on multiple operating systems, packaging the build artifacts, and creating a GitHub release when a new version tag is pushed.

**Build and release automation:**

* Added a `.github/workflows/build.yml` workflow that triggers on pushes to version tags, pull requests, or manual dispatch. It builds the project using CMake and the Rust toolchain, currently enabled for Windows (with macOS and Linux steps commented out).
* The workflow installs necessary dependencies, builds the project in release mode, and packages the resulting artifacts for each platform.
* Artifacts are uploaded for each build, and when a tag is pushed, a GitHub Release is created with the packaged artifacts attached.